### PR TITLE
Add post about JupyterCon 2025

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ plugins:
 theme: minima
 title: JupyterLab News
 description: Subscribe to get news about JupyterLab.
-baseurl: /assets
+baseurl: /assets-test
 exclude:
   - src
   - README.md

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ plugins:
 theme: minima
 title: JupyterLab News
 description: Subscribe to get news about JupyterLab.
-baseurl: /assets-test
+baseurl: /assets
 exclude:
   - src
   - README.md

--- a/_posts/2025-09-19-JupyterCon-2025.md
+++ b/_posts/2025-09-19-JupyterCon-2025.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "JupyterCon 2025 · Nov 4-5 · San Diego"
+date: 2025-09-16 00:00:00 -0000
+categories: posts
+excerpt: "Register at https://jupytercon.com"
+---
+
+Join us for [JupyterCon 2025](https://jupytercon.com) on November 4-5, 2025, in San Diego, California, USA.
+
+Tutorials are Nov 3, the main conference is Nov 4-5, and code sprints are Nov 6.
+
+* [Register](https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce/)
+* [View Schedule](https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce)
+* If your organization would like to sponsor JupyterCon, see the [Sponsorship opportunities](https://events.linuxfoundation.org/jupytercon/sponsor/?ajs_aid=024012d5-911c-4982-8323-5ebe09e57be6)


### PR DESCRIPTION
We'd like to get the word out about JupyterCon everywhere we can. One idea was to create a news item to be served by the JupyterLab opt-in notification system.

Notification: 
<img width="169" height="85" alt="image" src="https://github.com/user-attachments/assets/e44b8b6b-1b2d-4454-9c34-7bbb3c9b16c2" />

Full post:
<img width="787" height="365" alt="image" src="https://github.com/user-attachments/assets/2b59ed76-de12-400f-86bb-1dcd61ef2321" />
